### PR TITLE
Move dummy model to `api.py` and improve the /api/predict/ endpoint.

### DIFF
--- a/dockerfiles/api.dockerfile
+++ b/dockerfiles/api.dockerfile
@@ -10,7 +10,6 @@ WORKDIR /
 COPY deps/requirements_api.txt requirements.txt
 COPY pyproject.toml .
 COPY src/dtu_mlops_project/api.py .
-COPY src/dtu_mlops_project/model.py .
 
 RUN touch __init__.py
 RUN pip install -r requirements.txt --no-cache-dir

--- a/src/dtu_mlops_project/api.py
+++ b/src/dtu_mlops_project/api.py
@@ -16,7 +16,7 @@ def get_labels() -> dict:
     """
     Loads and caches the labels for the corresponding class indices.
     """
-    with open("src/dtu_mlops_project/imagenet-simple-labels.json", "r") as f:
+    with open("src/dtu_mlops_project/imagenet-simple-labels.json") as f:
         labels = json.load(f)
     return labels
 
@@ -123,10 +123,7 @@ def api_predict(image_file: fastapi.UploadFile):
 
     labels = get_labels()
 
-    results = {
-        labels[clz.item()]: prob.item()
-        for prob, clz in zip(probs[0], classes[0])
-    }
+    results = {labels[clz.item()]: prob.item() for prob, clz in zip(probs[0], classes[0])}
     logger.debug(f"Final results: '{results}'")
 
     return HTTP_200_OK | {

--- a/src/dtu_mlops_project/api.py
+++ b/src/dtu_mlops_project/api.py
@@ -1,17 +1,58 @@
+import functools
 from contextlib import asynccontextmanager
 from http import HTTPStatus
+import json
+import typing
 
 import fastapi
+import torch
+import timm
 from loguru import logger
 from PIL import Image
 
-try:
-    import model
-except (ImportError, ModuleNotFoundError):
-    from . import model
+
+@functools.cache
+def get_labels() -> dict:
+    """
+    Loads and caches the labels for the corresponding class indices.
+    """
+    with open("src/dtu_mlops_project/imagenet-simple-labels.json", "r") as f:
+        labels = json.load(f)
+    return labels
 
 
-dummy_model = model.get_dummy_model()
+@functools.cache
+def get_dummy_model() -> typing.Callable:
+    """
+    Initializes a 'dummy' model ('mobilenetv4') for temporary use.
+
+    :returns: A callable which can run the initialized model.
+    """
+    model_name = "mobilenetv4_conv_small.e2400_r224_in1k"
+    mobilenetv4_model = timm.create_model(model_name, pretrained=True)
+    mobilenetv4_model = mobilenetv4_model.eval()
+
+    data_config = timm.data.resolve_model_data_config(mobilenetv4_model)
+    transforms = timm.data.create_transform(**data_config, is_training=False)
+
+    def _run_model(image, k: int = 5) -> tuple:
+        """
+        Runs the model on an image object with and computes the top 'k'
+        probabilities and their associated class indices.
+
+        :param image: The image to run the model on.
+        :param k: The number of classes to return.
+        :returns: a tuple of top 'k' class indices and their probabilities.
+        """
+        output = mobilenetv4_model(transforms(image).unsqueeze(0))
+
+        probabilities, class_indices = torch.topk(output.softmax(dim=1) * 100, k=k)
+        return probabilities, class_indices
+
+    return _run_model
+
+
+dummy_model = get_dummy_model()
 
 IMAGE_MIME_TYPES = ("image/jpeg", "image/png", "image/svg", "image/svg+xml")
 
@@ -80,7 +121,14 @@ def api_predict(image_file: fastapi.UploadFile):
     probs, classes = dummy_model(image)
     logger.debug(f"Dummy model computed probabilities: '{probs}' with corresponding class indices: '{classes}'")
 
+    labels = get_labels()
+
+    results = {
+        labels[clz.item()]: prob.item()
+        for prob, clz in zip(probs[0], classes[0])
+    }
+    logger.debug(f"Final results: '{results}'")
+
     return HTTP_200_OK | {
-        "probabilities": probs,
-        "classification_indices": classes,
+        "probabilities": results,
     }

--- a/src/dtu_mlops_project/model.py
+++ b/src/dtu_mlops_project/model.py
@@ -1,43 +1,9 @@
-import functools
-import typing
-
 import timm
 import torch
 import typer
 from torch import nn
 
 app = typer.Typer()
-
-
-@functools.cache
-def get_dummy_model() -> typing.Callable:
-    """
-    Initializes a 'dummy' model ('mobilenetv4') for temporary use.
-
-    :returns: A callable which can run the initialized model.
-    """
-    model_name = "mobilenetv4_conv_small.e2400_r224_in1k"
-    mobilenetv4_model = timm.create_model(model_name, pretrained=True)
-    mobilenetv4_model = mobilenetv4_model.eval()
-
-    data_config = timm.data.resolve_model_data_config(mobilenetv4_model)
-    transforms = timm.data.create_transform(**data_config, is_training=False)
-
-    def _run_model(image, k: int = 5) -> tuple:
-        """
-        Runs the model on an image object with and computes the top 'k'
-        probabilities and their associated class indices.
-
-        :param image: The image to run the model on.
-        :param k: The number of classes to return.
-        :returns: a tuple of top 'k' class indices and their probabilities.
-        """
-        output = mobilenetv4_model(transforms(image).unsqueeze(0))
-
-        probabilities, class_indices = torch.topk(output.softmax(dim=1) * 100, k=k)
-        return probabilities, class_indices
-
-    return _run_model
 
 
 class MyAwesomeModel(nn.Module):


### PR DESCRIPTION
This PR improves the `/api/predict/` endpoint with human-readable classes in the responses and the `model.py` is no longer needed to be imported.